### PR TITLE
ULP-3127: Support the current API.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,7 +44,7 @@ var OAuth2Strategy = require('passport-oauth2')
 function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://id.smt.docomo.ne.jp/cgi8/oidc/authorize';
-  options.tokenURL = options.tokenURL || 'https://conf.uw.docomo.ne.jp/token';
+  options.tokenURL = options.tokenURL || 'https://conf.uw.docomo.ne.jp/common/token';
   options.scope = options.scope || 'openid';
 
   options.customHeaders = options.customHeaders || {};
@@ -56,8 +56,13 @@ function Strategy(options, verify) {
   OAuth2Strategy.call(this, options, verify);
 
   this.name = 'daccount';
-  this._profileURL = options.profileURL || 'https://conf.uw.docomo.ne.jp/userinfo';
+  this._profileURL = options.profileURL || 'https://conf.uw.docomo.ne.jp/common/userinfo';
   this._generateState = !!(options.store || options.state);
+  // The defaults that follow ensure this works in most authentication flows.
+  this._params = {
+    authif: options.authif || '1',
+    idauth: options.idauth || '1'
+  };
 }
 
 // Inherit from `OAuth2Strategy`.
@@ -75,9 +80,9 @@ util.inherits(Strategy, OAuth2Strategy);
  * @access protected
  */
 Strategy.prototype.authorizationParams = function (options) {
-  var params = {
+  var params = Object.assign({
     nonce: options.nonce || uid(32)
-  };
+  }, this._params);
   
   if (!this._generateState && !options.state) {
     // ensure state value if a state store and a state value were not specified

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-daccount",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Docomo dAccount authentication strategy for Passport.",
   "keywords": [
     "passport",


### PR DESCRIPTION
### Description
Support the current DAccount API.

### References
- ULP-3127

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
