### PR TITLE
chore(security): uses pinned versions of actions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
     steps:
-      - uses: actions/checkout@v2
-      - uses: returntocorp/semgrep-action@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 on 2026-06-09, TODO: use a release instead
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use pinned commit SHAs for all third-party actions, improving security and reproducibility.
<!-- PR created with github.com/jcchavezs/pin-gha -->